### PR TITLE
Fix Commit Count not showing for the last day of the month

### DIFF
--- a/GitHelper-1/Controllers/DashboardController.cs
+++ b/GitHelper-1/Controllers/DashboardController.cs
@@ -215,7 +215,7 @@ namespace GitHelper_1.Controllers
 
                 int numberOfDays = DateTime.DaysInMonth(localFirstDateOfMonth.Year, localFirstDateOfMonth.Month);
 
-                DateTimeOffset localLastDateofMonth = DateFormatter.CreateUserPrefDateTimeOffset(new DateTime(localFirstDateOfMonth.Year, localFirstDateOfMonth.Month, numberOfDays));
+                DateTimeOffset localLastDateofMonth = localFirstDateOfMonth.AddMonths(1).Subtract(TimeSpan.FromTicks(1));
 
 
                 //call function to get commit list for specified dates


### PR DESCRIPTION
Initially the last timestamp for graph commit fetching was set as the 00:00:00 of the last date of the month. But now the last timestamp is set as 00:00:00 of the 1st date of the next month -1 tick. With this, all commits for the last day with be fetched for graph data calculation